### PR TITLE
fix: use correct GitHub Actions bot email with numeric ID

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -18,16 +18,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Debug Bot Identity
+      - name: Debug Identity
         run: |
           echo "Current git config:"
           git config --list
           echo "GitHub Context:"
           echo "Actor: ${{ github.actor }}"
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Event Actor: ${{ github.event.sender.login }}"
           echo "Server URL: ${{ github.server_url }}"
           echo "Repository: ${{ github.repository }}"
-      
+          
       # Only run in GitHub Actions environment, not during local testing
       - name: Import GPG key
         if: ${{ !env.ACT }}
@@ -40,13 +43,20 @@ jobs:
           git_commit_gpgsign: true
           git_user_name: github-actions[bot]
           git_user_email: github-actions[bot]@users.noreply.github.com
-      
+          
       - name: Verify GPG Setup
         if: ${{ !env.ACT }}
         run: |
           echo "After GPG import:"
           git config --list
           gpg --list-secret-keys --keyid-format LONG
+          
+      # Force the commit to be made as the GitHub Actions bot
+      - name: Configure Git for GitHub Actions
+        if: ${{ !env.ACT }}
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
       
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Description
Updates the GitHub Actions bot email to use the correct format with numeric ID for proper commit attribution.

Changes:
- Updated bot email to: 41898282+github-actions[bot]@users.noreply.github.com
- Added GitHub token to checkout step
- Enhanced debug output for identity verification
- Added local git configuration for bot commits

Technical Details:
- Uses correct numeric ID (41898282) for GitHub Actions bot
- Maintains GPG signing configuration
- Adds detailed identity debugging
- Uses local git config to avoid global changes

Debug Information Added:
- Current git configuration
- GitHub actor and event information
- Event sender details
- Repository context
- GPG setup verification

## Type of Change
version: fix      # Patch version bump

## Testing
- [ ] Verified correct bot email format
- [ ] Confirmed GitHub token is properly used
- [ ] Tested workflow locally using `act` (skips GPG steps)
- [ ] Verified debug output shows correct identity information

## Next Steps
After this PR:
1. Verify commits are properly attributed to GitHub Actions bot
2. Confirm commits are signed with correct identity
3. Monitor automated commits in production environment