### PR TITLE
fix: use GitHub App token for proper bot attribution

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -15,10 +15,17 @@ jobs:
     outputs:
       pr_number: ${{ steps.get_pr.outputs.pr_number }}
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+          
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
       
       - name: Debug Identity
         run: |
@@ -28,6 +35,7 @@ jobs:
           echo "Actor: ${{ github.actor }}"
           echo "Event Name: ${{ github.event_name }}"
           echo "Event Actor: ${{ github.event.sender.login }}"
+          echo "Token Actor: ${{ steps.generate_token.actor }}"
           echo "Server URL: ${{ github.server_url }}"
           echo "Repository: ${{ github.repository }}"
           
@@ -42,7 +50,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_user_name: github-actions[bot]
-          git_user_email: github-actions[bot]@users.noreply.github.com
+          git_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
           
       - name: Verify GPG Setup
         if: ${{ !env.ACT }}


### PR DESCRIPTION
## Description
Implements GitHub App authentication to ensure proper bot attribution and signed commits.

Changes:
- Added GitHub App token generation
- Updated checkout to use App token
- Enhanced debug output for token verification
- Maintained GPG signing configuration

Technical Details:
- Uses tibdex/github-app-token@v2 for token generation
- Requires new repository secrets:
  - BOT_APP_ID: GitHub App ID
  - BOT_PRIVATE_KEY: GitHub App private key
- Uses correct bot email with numeric ID
- Maintains existing GPG signing setup

Prerequisites:
1. Create GitHub App with necessary permissions:
   - Contents: write
   - Pull requests: write
2. Install App on repository
3. Add required secrets to repository

## Type of Change
version: fix      # Patch version bump

## Testing
- [ ] Created and configured GitHub App
- [ ] Added required secrets to repository
- [ ] Verified token generation
- [ ] Confirmed proper bot attribution in debug output
- [ ] Tested workflow locally using `act` (skips token generation)

## Next Steps
After this PR:
1. Verify commits are properly attributed to bot
2. Confirm commits are signed correctly
3. Document GitHub App setup process
4. Monitor automated commits in production