### PR TITLE
fix: add GPG public key export for GitHub verification

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -181,6 +181,12 @@ jobs:
           
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
+      - name: Export and Display Public Key
+        if: ${{ !env.ACT }}
+        run: |
+          echo "GPG Public Key for GitHub:"
+          gpg --armor --export 90CD8F6F3E6CEBD6
+
   merge-pr:
     needs: version-bump
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Adds step to export GPG public key to fix unverified commit status.

Changes:
- Added GPG public key export step
- Maintained existing GPG signing configuration
- Added key ID reference: 90CD8F6F3E6CEBD6

Technical Details:
- Exports public key in ASCII armor format
- Displays key for easy copying to GitHub
- Uses identified key from current unverified commits
- Maintains existing bot identity configuration

Required Manual Steps After Merge:
1. Run workflow and copy the exported public key
2. Go to GitHub Settings → SSH and GPG keys
3. Click "New GPG key"
4. Paste the exported public key (including BEGIN and END markers)
5. Click "Add GPG key"

## Type of Change
version: fix      # Patch version bump

## Testing
- [ ] Verified GPG key export step
- [ ] Confirmed key ID matches unverified commits
- [ ] Tested workflow locally using `act` (skips GPG steps)
- [ ] Prepared documentation for key addition

## Next Steps
After merging to main:
1. Run workflow and capture public key
2. Add public key to GitHub GPG keys
3. Verify next automated commit shows as