### PR TITLE
fix: align GitHub Actions bot identity with GPG key details

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -42,8 +42,8 @@ jobs:
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
-          git_user_name: github-actions[bot]
-          git_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          git_user_name: "GitHub Actions Bot"
+          git_user_email: "github-actions-bot@users.noreply.github.com"
           
       - name: Display GPG Keys and Export Public Key
         if: ${{ !env.ACT }}
@@ -52,8 +52,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
           
           echo -e "\nGPG Public Key for GitHub:"
-          KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
-          gpg --armor --export $KEY_ID
+          gpg --armor --export 90CD8F6F3E5CEBD6
       
       - name: Verify GPG Setup
         if: ${{ !env.ACT }}


### PR DESCRIPTION
## Description
Updates bot identity to match the GPG key details exactly, ensuring proper commit verification.

Changes:
- Updated bot name to: "GitHub Actions Bot"
- Updated bot email to: "github-actions-bot@users.noreply.github.com"
- Using exact key ID: 90CD8F6F3E5CEBD6
- Maintained GPG key export functionality

Technical Details:
Key Information: