### PR TITLE
fix: align workflow identity with registered GPG key

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -42,7 +42,7 @@ jobs:
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
-          git_user_name: "github-actions[bot]"
+          git_user_name: "GitHub Actions Bot v2025.01.22"
           git_user_email: "github-actions-bot@users.noreply.github.com"
           
       - name: Display GPG Keys and Export Public Key


### PR DESCRIPTION
## Description
Updates workflow to use exact identity matching registered GPG key.

Changes:
- Updated bot name to: "GitHub Actions Bot v2025.01.22"
- Maintained email: "github-actions-bot@users.noreply.github.com"
- Kept existing GPG signing configuration

Technical Details:
- Matches GPG key identity exactly:
  - Key ID: 90CD8F6F3E5CEBD6
  - Name: GitHub Actions Bot v2025.01.22
  - Email: github-actions-bot@users.noreply.github.com
- Uses existing GPG key (no regeneration needed)
- Maintains current signing setup

## Type of Change
version: fix      # Patch version bump

## Testing
- [ ] Verified name matches GPG key exactly
- [ ] Confirmed email matches GPG key
- [ ] Tested workflow syntax
- [ ] Verified key ID matches

## Next Steps
After merging:
1. Monitor next automated commit
2. Verify commit shows as verified
3. Check commit author matches GPG key identity
4. Document successful configuration

## Why This Should Work
The workflow will now use the exact identity that's registered with the GPG key in GitHub, which should resolve the verification issue without requiring new key generation.