### PR TITLE
refactor: Update NHL Edge API matchup types and remove streak display

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/app/api/nhl/game-center/route.ts
+++ b/apps/sploosh-ai-hockey-analytics/app/api/nhl/game-center/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
 
     try {
         const data = await fetchNHLEdge(NHL_EDGE_ENDPOINTS.gameCenter(gameId))
+        // console.log('Game Center Response:', JSON.stringify(data, null, 2))
         return NextResponse.json(data)
     } catch (error) {
         console.error('NHL Edge API Error:', error)

--- a/apps/sploosh-ai-hockey-analytics/app/api/nhl/game-center/route.ts
+++ b/apps/sploosh-ai-hockey-analytics/app/api/nhl/game-center/route.ts
@@ -12,7 +12,6 @@ export async function GET(request: Request) {
 
     try {
         const data = await fetchNHLEdge(NHL_EDGE_ENDPOINTS.gameCenter(gameId))
-        // console.log('Game Center Response:', JSON.stringify(data, null, 2))
         return NextResponse.json(data)
     } catch (error) {
         console.error('NHL Edge API Error:', error)

--- a/apps/sploosh-ai-hockey-analytics/components/features/games/card/game-card.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/card/game-card.tsx
@@ -152,28 +152,12 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
                                         {game.awayTeam.sog !== undefined && <span className="min-w-[45px]">{game.awayTeam.sog} SOG</span>}
                                         <span>{game.awayTeam.record}</span>
                                     </div>
-                                    {game.matchup?.last10Record && (
-                                        <span className="text-[9px] opacity-75">
-                                            <span className="mr-1">
-                                                {game.matchup.last10Record.awayTeam.streakType}{game.matchup.last10Record.awayTeam.streak}
-                                            </span>
-                                            {game.matchup.last10Record.awayTeam.record}
-                                        </span>
-                                    )}
                                 </div>
                                 <div className="flex flex-col items-end gap-0.5">
                                     <div className="flex items-center gap-2">
                                         <span>{game.homeTeam.record}</span>
                                         {game.homeTeam.sog !== undefined && <span className="min-w-[45px] text-right">{game.homeTeam.sog} SOG</span>}
                                     </div>
-                                    {game.matchup?.last10Record && (
-                                        <span className="text-[9px] opacity-75">
-                                            <span className="mr-1">
-                                                {game.matchup.last10Record.homeTeam.streakType}{game.matchup.last10Record.homeTeam.streak}
-                                            </span>
-                                            {game.matchup.last10Record.homeTeam.record}
-                                        </span>
-                                    )}
                                 </div>
                             </div>
                         </div>
@@ -207,6 +191,14 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
                 >
                     NHL Game Center
                 </button>
+
+                {game.matchup?.skaterComparison && (
+                    <div className="text-[9px] opacity-75">
+                        <span className="mr-1">
+                            Points Leader: {game.matchup.skaterComparison.leaders.find(l => l.category === 'points')?.homeLeader.name.default}
+                        </span>
+                    </div>
+                )}
             </div>
         </div>
     )

--- a/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
@@ -51,7 +51,6 @@ export function GamesList({ date, onGameSelect, onClose }: GamesListProps) {
                                 throw new Error(`HTTP error! status: ${response.status}`)
                             }
                             const gameCenterData = await response.json()
-                            // console.log(`Game center data for game ${game.id}:`, gameCenterData)
                             return {
                                 ...game,
                                 specialEvent: gameCenterData.specialEvent,

--- a/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
@@ -46,13 +46,16 @@ export function GamesList({ date, onGameSelect, onClose }: GamesListProps) {
                     if (isInitialLoad || isDateChange) {
                         try {
                             const response = await fetch(`/api/nhl/game-center?gameId=${game.id}`)
-                            if (response.ok) {
-                                const gameCenterData = await response.json()
-                                return {
-                                    ...game,
-                                    specialEvent: gameCenterData.specialEvent,
-                                    matchup: gameCenterData.matchup
-                                }
+                            if (!response.ok) {
+                                console.error(`Game center fetch failed for game ${game.id}:`, await response.text())
+                                throw new Error(`HTTP error! status: ${response.status}`)
+                            }
+                            const gameCenterData = await response.json()
+                            // console.log(`Game center data for game ${game.id}:`, gameCenterData)
+                            return {
+                                ...game,
+                                specialEvent: gameCenterData.specialEvent,
+                                matchup: gameCenterData.matchup
                             }
                         } catch (error) {
                             console.error(`Failed to fetch game center data for game ${game.id}:`, error)

--- a/apps/sploosh-ai-hockey-analytics/types/nhl-edge.ts
+++ b/apps/sploosh-ai-hockey-analytics/types/nhl-edge.ts
@@ -114,18 +114,57 @@ export interface NHLEdgeRosterSpot {
     position: string
 }
 
-export interface NHLEdgeTeamLast10Record {
-    record: string
-    streakType: 'W' | 'L' | 'O'
-    streak: number
-}
-
-export interface NHLEdgeLast10Record {
-    awayTeam: NHLEdgeTeamLast10Record
-    homeTeam: NHLEdgeTeamLast10Record
-}
-
 export interface NHLEdgeMatchup {
-    last10Record: NHLEdgeLast10Record
-    // ... other matchup properties if needed ...
+    season: number
+    gameType: number
+    skaterComparison: {
+        contextLabel: string
+        contextSeason: number
+        leaders: Array<{
+            category: string
+            awayLeader: NHLEdgeSkaterLeader
+            homeLeader: NHLEdgeSkaterLeader
+        }>
+    }
+    goalieComparison: {
+        contextLabel: string
+        contextSeason: number
+        homeTeam: NHLEdgeGoalieStats
+        awayTeam: NHLEdgeGoalieStats
+    }
+    skaterSeasonStats: {
+        contextLabel: string
+        contextSeason: number
+        skaters: NHLEdgeSkaterStats[]
+    }
+    goalieSeasonStats: {
+        contextLabel: string
+        contextSeason: number
+        goalies: NHLEdgeGoalieStats[]
+    }
+}
+
+interface NHLEdgeSkaterLeader {
+    playerId: number
+    name: {
+        default: string
+    }
+    firstName: {
+        default: string
+    }
+    lastName: {
+        default: string
+    }
+    sweaterNumber: number
+    positionCode: string
+    headshot: string
+    value: number
+}
+
+export interface NHLEdgeGoalieStats {
+    // Define the structure of NHLEdgeGoalieStats
+}
+
+export interface NHLEdgeSkaterStats {
+    // Define the structure of NHLEdgeSkaterStats
 } 


### PR DESCRIPTION
## Changes
- Updated `NHLEdgeMatchup` interface to match current NHL Edge API response structure
- Removed unused streak-related types (`NHLEdgeTeamLast10Record`, `NHLEdgeLast10Record`)
- Added new types for skater and goalie comparisons
- Removed streak display from GameCard component

## Code Changes
- Updated types in `types/nhl-edge.ts`: