### PR TITLE
feat: implement GitHub Actions bot GPG signing

### DIFF
--- a/.github/scripts/generate-gpg-key.sh
+++ b/.github/scripts/generate-gpg-key.sh
@@ -1,24 +1,41 @@
 #!/bin/bash
 
 # Configuration
-BOT_NAME="GitHub Actions Bot"
-BOT_EMAIL="github-actions-bot@users.noreply.github.com"
-KEY_COMMENT="GPG key for automated commits"
+BOT_NAME="GitHub Actions Bot (SplooshAI)"
+BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+KEY_COMMENT="Automated commits for SplooshAI"
+
+PASSPHRASE="d3f3nd!t"
+# # Prompt for passphrase
+# echo "Enter passphrase for new GPG key:"
+# read -s PASSPHRASE
+# echo "Confirm passphrase:"
+# read -s PASSPHRASE_CONFIRM
+
+# if [ "$PASSPHRASE" != "$PASSPHRASE_CONFIRM" ]; then
+#     echo "Error: Passphrases do not match"
+#     exit 1
+# fi
+
+# if [ -z "$PASSPHRASE" ]; then
+#     echo "Error: Passphrase cannot be empty"
+#     exit 1
+# fi
 
 # Generate GPG key configuration file
 cat > gpg-key-config <<EOF
 %echo Generating GPG key for GitHub Actions
-Key-Type: ED25519
-Key-Curve: ed25519
+Key-Type: RSA
+Key-Length: 4096
 Key-Usage: sign
-Subkey-Type: ECDH
-Subkey-Curve: cv25519
+Subkey-Type: RSA
+Subkey-Length: 4096
 Subkey-Usage: encrypt
 Name-Real: $BOT_NAME
 Name-Comment: $KEY_COMMENT
 Name-Email: $BOT_EMAIL
 Expire-Date: 0
-%no-protection
+Passphrase: $PASSPHRASE
 %commit
 %echo Done
 EOF
@@ -40,4 +57,5 @@ rm gpg-key-config
 
 echo -e "\nKey generation complete!"
 echo "Key ID: $KEY_ID"
-echo "Email: $BOT_EMAIL" 
+echo "Email: $BOT_EMAIL"
+echo "Remember to store the passphrase securely - you'll need it for the GPG_PASSPHRASE secret in GitHub" 

--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -21,18 +21,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Debug Identity
-        run: |
-          echo "Current git config:"
-          git config --list
-          echo "GitHub Context:"
-          echo "Actor: ${{ github.actor }}"
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Event Actor: ${{ github.event.sender.login }}"
-          echo "Server URL: ${{ github.server_url }}"
-          echo "Repository: ${{ github.repository }}"
-          
-      # Only run in GitHub Actions environment, not during local testing
       - name: Import GPG key
         if: ${{ !env.ACT }}
         uses: crazy-max/ghaction-import-gpg@v6
@@ -42,9 +30,23 @@ jobs:
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
-          git_user_name: "GitHub Actions Bot v2025.01.22"
-          git_user_email: "github-actions-bot@users.noreply.github.com"
+          git_user_name: "github-actions[bot]"
+          git_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
           
+      - name: Debug Identity
+        if: ${{ !env.ACT }}
+        run: |
+          echo "After GPG import:"
+          git config --list
+          echo "GPG Keys:"
+          gpg --list-secret-keys --keyid-format LONG
+          echo "Git Identity:"
+          git config --get user.name
+          git config --get user.email
+          echo "GitHub Context:"
+          echo "Actor: ${{ github.actor }}"
+          echo "Event Name: ${{ github.event_name }}"
+      
       - name: Display GPG Keys and Export Public Key
         if: ${{ !env.ACT }}
         run: |


### PR DESCRIPTION
## Description

This PR implements proper GPG signing for commits made by the GitHub Actions bot. Key changes:

1. Added `.github/scripts/generate-gpg-key.sh` for automated GPG key generation
2. Updated main-merge workflow to use correct GitHub Actions bot identity:
   - Name: `github-actions[bot]`
   - Email: `41898282+github-actions[bot]@users.noreply.github.com`
3. Added documentation for GPG setup and management

## Implementation Details

- Script generates RSA-4096 keys with proper bot identity
- Workflow uses `crazy-max/ghaction-import-gpg@v6` for key management
- Added debug steps to verify GPG configuration
- Updated documentation with key rotation and security best practices

## Testing
- [x] Generated new GPG key with correct bot identity
- [x] Added key to GitHub and repository secrets
- [x] Verified workflow configuration
- [x] Tested locally using `act`

## Documentation References