### PR TITLE
fix: skip Vercel deployment check in local act environment

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -62,6 +62,7 @@ jobs:
           fi
 
       - name: Wait for Vercel Preview
+        if: ${{ !env.ACT }}  # Only run in GitHub Actions, not in local act
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Description
Updates the semantic PR check workflow to properly handle local testing with `act` by skipping the Vercel deployment check step when running locally. This aligns with our documented testing guidelines and improves the local development experience.

## Type of Change
version: fix     # Bug fix (patch version bump)

## Changes Made
- Added conditional check `if: ${{ !env.ACT }}` to Vercel deployment step
- Ensures workflow matches documented behavior in TESTING.md
- Maintains full checks in GitHub environment while streamlining local testing

## Testing
- [ ] I have tested these changes locally using `act`
- [ ] All existing tests pass

## Related Documentation
- Follows guidelines in `.github/docs/TESTING.md`
- Aligns with local testing expectations documented in README.md

## Impact
- Local testing will no longer hang waiting for Vercel deployment
- No impact on actual GitHub Actions environment behavior
- Improves developer experience when testing workflows locally