### PR TITLE
fix: remove GPG signing disable for GitHub Actions bot

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -27,8 +27,6 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Temporarily disable GPG signing for npm version
-          git config --global commit.gpgsign false
       
       - name: Debug Identity
         if: ${{ !env.ACT }}


### PR DESCRIPTION
## Description
Removes the explicit GPG signing disable in the main-merge workflow to allow GitHub Actions bot to use its default signing behavior. This ensures all automated version bump commits are properly signed.

## Type of Change
version: fix     # Bug fix (patch version bump)

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG