### PR TITLE
fix: enable commit signing for GitHub Actions bot

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global commit.gpgsign true
       
       - name: Debug Identity
         if: ${{ !env.ACT }}


### PR DESCRIPTION
## Description
Enables commit signing for GitHub Actions bot by adding git config setting. This ensures automated version bump commits are properly signed.

## Type of Change
version: fix     # Bug fix (patch version bump)

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG