### PR TITLE
docs: update README to reflect bot signing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This project uses semantic versioning with automated version bumps and requires 
 2. A new PR is automatically created with:
    - Updated version numbers in all package.json files
    - Automated testing and validation
-   - GPG-signed commits from the GitHub Actions bot
    - Auto-merge once checks pass
 
 ## Signed Commits


### PR DESCRIPTION
## Description
Updates README to accurately reflect that GitHub Actions bot commits are not GPG-signed. This improves documentation accuracy by removing incorrect claims about automated commit signing.

## Type of Change
version: docs     # Documentation changes

## Testing
- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG