### PR TITLE
fix: Implement robust retry logic for network errors when fetching games

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
@@ -208,7 +208,7 @@ export function GamesList({ date, onGameSelect, onClose }: GamesListProps) {
 
             fetchData()
         }
-    }, [debouncedDate, isNavigating, date, error])
+    }, [debouncedDate, isNavigating, date, error, autoRefreshEnabled])
 
     // Auto-refresh timer
     useEffect(() => {
@@ -233,6 +233,8 @@ export function GamesList({ date, onGameSelect, onClose }: GamesListProps) {
     if (isLoading && !games.length) {
         return <GamesListSkeleton />
     }
+
+    // We'll use retryCount in the error message logic
 
     return (
         <div ref={containerRef} className="space-y-4">

--- a/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
@@ -230,16 +230,16 @@ export function GamesList({ date, onGameSelect, onClose }: GamesListProps) {
         }
     }, [autoRefreshEnabled, lastRefreshTime, fetchGames])
 
-    if (isLoading && !games.length) {
-        return <GamesListSkeleton />
-    }
-
     // Log retry count for debugging purposes
     useEffect(() => {
         if (retryCount > 0) {
             console.log(`Retry attempt ${retryCount} of ${MAX_RETRY_ATTEMPTS}`)
         }
     }, [retryCount])
+
+    if (isLoading && !games.length) {
+        return <GamesListSkeleton />
+    }
 
     return (
         <div ref={containerRef} className="space-y-4">

--- a/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/list/games-list.tsx
@@ -234,7 +234,12 @@ export function GamesList({ date, onGameSelect, onClose }: GamesListProps) {
         return <GamesListSkeleton />
     }
 
-    // We'll use retryCount in the error message logic
+    // Log retry count for debugging purposes
+    useEffect(() => {
+        if (retryCount > 0) {
+            console.log(`Retry attempt ${retryCount} of ${MAX_RETRY_ATTEMPTS}`)
+        }
+    }, [retryCount])
 
     return (
         <div ref={containerRef} className="space-y-4">


### PR DESCRIPTION
## Description

This PR fixes the "Failed to fetch games: TypeError: Failed to fetch" error by implementing robust retry logic and intelligent auto-refresh management. The implementation includes:

- Added automatic retry mechanism (up to 3 attempts) with 20-second intervals matching the regular refresh rate
- Added clear error messaging showing retry progress during retries
- Added manual "Retry Now" button when all automatic retries fail
- Implemented intelligent auto-refresh management based on network connectivity and game status
- Auto-refresh now automatically re-enables when connectivity is restored and active games are present

This fix significantly improves the user experience during network disruptions by providing clear feedback and automatic recovery mechanisms.

## Type of Change
version: fix      # Bug fix (patch version bump)

## Testing
- [x] I have tested these changes locally using Chrome DevTools to simulate network failures
- [x] Verified retry attempts occur at proper 20-second intervals
- [x] Confirmed auto-refresh disables after max retries to prevent continuous failing requests
- [x] Verified auto-refresh re-enables correctly when connectivity is restored and active games are present
- [x] Tested the "Retry Now" button functionality for manual recovery