### PR TITLE
fix: Display correct overtime period numbers (OT, 2OT, 3OT) in sidebar

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/components/features/games/card/game-card.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/card/game-card.tsx
@@ -50,7 +50,10 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
             case 'LIVE':
                 if (game.clock?.inIntermission) {
                     if (game.periodDescriptor?.periodType === 'OT') {
-                        return `OT INT - ${game.clock?.timeRemaining}`
+                        // Calculate OT period number (4th period is 1OT, 5th is 2OT, etc.)
+                        const otPeriodNum = game.periodDescriptor.number - 3;
+                        const otDisplay = otPeriodNum > 1 ? `${otPeriodNum}OT` : 'OT';
+                        return `${otDisplay} INT - ${game.clock?.timeRemaining}`
                     } else if (game.periodDescriptor?.periodType === 'SO') {
                         return `SO INT - ${game.clock?.timeRemaining}`
                     } else {
@@ -62,7 +65,10 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
                 }
                 if (game.periodDescriptor) {
                     if (game.periodDescriptor.periodType === 'OT') {
-                        return `OT - ${game.clock?.timeRemaining}`
+                        // Calculate OT period number (4th period is 1OT, 5th is 2OT, etc.)
+                        const otPeriodNum = game.periodDescriptor.number - 3;
+                        const otDisplay = otPeriodNum > 1 ? `${otPeriodNum}OT` : 'OT';
+                        return `${otDisplay} - ${game.clock?.timeRemaining}`
                     } else if (game.periodDescriptor.periodType === 'SO') {
                         return `SO - ${game.clock?.timeRemaining}`
                     } else {
@@ -80,7 +86,10 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
             case 'FINAL':
             case 'OFF':
                 if (game.periodDescriptor?.periodType === 'OT') {
-                    return 'Final (OT)'
+                    // Calculate OT period number (4th period is 1OT, 5th is 2OT, etc.)
+                    const otPeriodNum = game.periodDescriptor.number - 3;
+                    const otDisplay = otPeriodNum > 1 ? `${otPeriodNum}OT` : 'OT';
+                    return `Final (${otDisplay})`
                 } else if (game.periodDescriptor?.periodType === 'SO') {
                     return 'Final (SO)'
                 }

--- a/apps/sploosh-ai-hockey-analytics/components/features/games/card/game-card.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/games/card/game-card.tsx
@@ -14,6 +14,13 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
         return team.logo || `https://assets.nhle.com/logos/nhl/svg/${team.abbrev}_light.svg`
     }
 
+    // Helper function to get the OT period display (OT, 2OT, 3OT, etc.)
+    const getOTPeriodDisplay = (periodNumber: number) => {
+        // Calculate OT period number (4th period is 1OT, 5th is 2OT, etc.)
+        const otPeriodNum = periodNumber - 3;
+        return otPeriodNum > 1 ? `${otPeriodNum}OT` : 'OT';
+    }
+
     const handleGameClick = (e: React.MouseEvent) => {
         if (onSelectGame) {
             onSelectGame(game.id)
@@ -50,9 +57,7 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
             case 'LIVE':
                 if (game.clock?.inIntermission) {
                     if (game.periodDescriptor?.periodType === 'OT') {
-                        // Calculate OT period number (4th period is 1OT, 5th is 2OT, etc.)
-                        const otPeriodNum = game.periodDescriptor.number - 3;
-                        const otDisplay = otPeriodNum > 1 ? `${otPeriodNum}OT` : 'OT';
+                        const otDisplay = getOTPeriodDisplay(game.periodDescriptor.number);
                         return `${otDisplay} INT - ${game.clock?.timeRemaining}`
                     } else if (game.periodDescriptor?.periodType === 'SO') {
                         return `SO INT - ${game.clock?.timeRemaining}`
@@ -65,9 +70,7 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
                 }
                 if (game.periodDescriptor) {
                     if (game.periodDescriptor.periodType === 'OT') {
-                        // Calculate OT period number (4th period is 1OT, 5th is 2OT, etc.)
-                        const otPeriodNum = game.periodDescriptor.number - 3;
-                        const otDisplay = otPeriodNum > 1 ? `${otPeriodNum}OT` : 'OT';
+                        const otDisplay = getOTPeriodDisplay(game.periodDescriptor.number);
                         return `${otDisplay} - ${game.clock?.timeRemaining}`
                     } else if (game.periodDescriptor.periodType === 'SO') {
                         return `SO - ${game.clock?.timeRemaining}`
@@ -86,9 +89,7 @@ export function GameCard({ game, onSelectGame, onClose }: GameCardProps) {
             case 'FINAL':
             case 'OFF':
                 if (game.periodDescriptor?.periodType === 'OT') {
-                    // Calculate OT period number (4th period is 1OT, 5th is 2OT, etc.)
-                    const otPeriodNum = game.periodDescriptor.number - 3;
-                    const otDisplay = otPeriodNum > 1 ? `${otPeriodNum}OT` : 'OT';
+                    const otDisplay = getOTPeriodDisplay(game.periodDescriptor.number);
                     return `Final (${otDisplay})`
                 } else if (game.periodDescriptor?.periodType === 'SO') {
                     return 'Final (SO)'


### PR DESCRIPTION
## Description

This PR fixes a bug in the sidebar where games that go to multiple overtime periods were always displayed as 'OT' instead of showing the correct overtime period number (2OT, 3OT, etc.).

The fix modifies the getGameStatus function in game-card.tsx to correctly display:
- 'OT' for the first overtime (period 4)
- '2OT' for the second overtime (period 5)
- '3OT' for the third overtime (period 6)
- And so on...

This change applies to all three scenarios:
1. During intermission: 'OT INT', '2OT INT', etc.
2. During play: 'OT', '2OT', etc.
3. Final score: 'Final (OT)', 'Final (2OT)', etc.

## Type of Change
version: fix      # Bug fix (patch version bump)

## Testing
- [x] I have tested these changes locally using the Docker development environment
- [x] The changes display correctly in the UI
- [x] My commits are signed with GPG