### PR TITLE
fix: improve slider display in portrait mode on iPhone

### DIFF
--- a/apps/sploosh-ai-hockey-analytics/app/demo/page.tsx
+++ b/apps/sploosh-ai-hockey-analytics/app/demo/page.tsx
@@ -165,7 +165,7 @@ export default function AnimationDemo() {
   }
 
   return (
-    <DemoLayout onGameSelect={handleGameSelect} title="Animated Data Points Demo">
+    <DemoLayout onGameSelect={handleGameSelect} title="Hockey Animation Demo">
       {error && (
         <div className="p-4 mb-4 bg-destructive/10 border border-destructive text-destructive rounded-md">
           {error}

--- a/apps/sploosh-ai-hockey-analytics/app/globals.css
+++ b/apps/sploosh-ai-hockey-analytics/app/globals.css
@@ -2,6 +2,54 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Custom styles for range inputs to improve appearance on iOS devices */
+input[type="range"] {
+  -webkit-appearance: none; /* Override default iOS styles */
+  appearance: none;
+  height: 8px;
+  background: #e2e8f0; /* Light gray background */
+  border-radius: 5px;
+  outline: none;
+  padding: 0;
+  margin: 10px 0;
+}
+
+/* Style the thumb */
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #3b82f6; /* Blue thumb */
+  cursor: pointer;
+  border: none;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #3b82f6;
+  cursor: pointer;
+  border: none;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+}
+
+/* Improve touch target size for mobile */
+@media (max-width: 640px) {
+  input[type="range"]::-webkit-slider-thumb {
+    width: 24px;
+    height: 24px;
+  }
+  
+  input[type="range"]::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+  }
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/apps/sploosh-ai-hockey-analytics/components/features/hockey-rink/rink-control-panel/rink-control-panel.tsx
+++ b/apps/sploosh-ai-hockey-analytics/components/features/hockey-rink/rink-control-panel/rink-control-panel.tsx
@@ -57,9 +57,10 @@ export const RinkControlPanel: React.FC<RinkControlPanelProps> = ({
           </div>
         </div>
         
-        <div className="flex items-center gap-4">
+        {/* Responsive control layout - stack on small screens, horizontal on larger screens */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
           {/* Play/Pause and Reset buttons */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 w-full sm:w-auto">
             <button
               onClick={() => setIsPlaying(!isPlaying)}
               className="px-3 py-1 bg-primary text-primary-foreground rounded-md text-sm font-medium shadow-lg"
@@ -75,9 +76,9 @@ export const RinkControlPanel: React.FC<RinkControlPanelProps> = ({
             </button>
           </div>
           
-          {/* Animation speed control */}
-          <div className="flex-1 flex items-center gap-2">
-            <label htmlFor="speed-slider" className="text-sm font-medium whitespace-nowrap">
+          {/* Animation speed control - full width on mobile */}
+          <div className="w-full sm:flex-1 flex items-center gap-2 mt-2 sm:mt-0">
+            <label htmlFor="speed-slider" className="text-sm font-medium whitespace-nowrap min-w-[70px]">
               Speed: {speed}x
             </label>
             <input
@@ -88,7 +89,8 @@ export const RinkControlPanel: React.FC<RinkControlPanelProps> = ({
               step={0.5}
               value={speed}
               onChange={(e) => setSpeed(parseFloat(e.target.value))}
-              className="flex-1"
+              className="w-full"
+              style={{ margin: '0 8px' }} /* Add some margin for better thumb visibility */
             />
           </div>
         </div>
@@ -130,10 +132,10 @@ export const RinkControlPanel: React.FC<RinkControlPanelProps> = ({
         {/* Right side controls */}
         <div className="w-full md:w-64 bg-card rounded-lg p-4 shadow-md flex flex-col">
           {/* Trail controls */}
-          <div className="space-y-2 mb-6">
+          <div className="space-y-3 mb-6">
             <h3 className="text-lg font-medium">Trail Settings</h3>
-            <div className="flex justify-between items-center">
-              <label htmlFor="trail-slider" className="text-sm font-medium">
+            <div className="flex flex-wrap justify-between items-center gap-2">
+              <label htmlFor="trail-slider" className="text-sm font-medium min-w-[120px]">
                 Trail Length: {trailLength}
               </label>
               <button 
@@ -143,17 +145,20 @@ export const RinkControlPanel: React.FC<RinkControlPanelProps> = ({
                 {showTrail ? 'Trail On' : 'Trail Off'}
               </button>
             </div>
-            <input
-              id="trail-slider"
-              type="range"
-              min={0}
-              max={10}
-              step={1}
-              value={trailLength}
-              onChange={(e) => setTrailLength(parseInt(e.target.value))}
-              className="w-full"
-              disabled={!showTrail}
-            />
+            <div className="px-1"> {/* Add padding to prevent thumb from touching edge */}
+              <input
+                id="trail-slider"
+                type="range"
+                min={0}
+                max={10}
+                step={1}
+                value={trailLength}
+                onChange={(e) => setTrailLength(parseInt(e.target.value))}
+                className="w-full"
+                style={{ margin: '0 8px' }} /* Add some margin for better thumb visibility */
+                disabled={!showTrail}
+              />
+            </div>
           </div>
           
           {/* Event Legend */}


### PR DESCRIPTION
## Description

This PR fixes the slider display bug in portrait mode on iPhone. The sliders were getting cut off and had poor usability on smaller screens, particularly in portrait orientation.

## Changes

- Enhanced responsive layout for animation controls
  - Made controls stack vertically on small screens
  - Improved horizontal spacing on all screen sizes
- Added proper spacing to prevent slider thumbs from touching screen edges
- Added custom CSS styles for better range input appearance on iOS
  - Customized slider track and thumb appearance
  - Increased touch target size for slider thumbs on mobile
  - Improved visual feedback for better usability

## Type of Change
version: fix      # Bug fix (patch version bump)

## Testing
- [x] Tested on iPhone in portrait mode
- [x] Verified slider functionality works correctly
- [x] Ensured consistent appearance across different screen sizes
